### PR TITLE
[FEAT] Add more compatibilities to 'between' filter

### DIFF
--- a/src/filter/field/field-filter-map.ts
+++ b/src/filter/field/field-filter-map.ts
@@ -100,8 +100,11 @@ export const LOOKUP_FILTER_MAP: Map<LookupFilter, BuildQueryFunction> = new Map(
       LookupFilter.BETWEEN,
       {
         build: (prop, value) => {
-          const rangeValues = value.split(',')
-          return { [prop]: Between(+rangeValues[0], +rangeValues[1]) }
+          const rangeValues = value
+            .split(',')
+            .map((rangeValue: string) => Number(rangeValue) || rangeValue)
+
+          return { [prop]: Between(rangeValues[0], rangeValues[1]) }
         },
       },
     ],

--- a/test/unit/field/field-filter.spec.ts
+++ b/test/unit/field/field-filter.spec.ts
@@ -159,6 +159,17 @@ describe('Test FieldFilter #buildQuery', () => {
     expect(built['where']['name']).toEqual(Between(1, 10))
   })
 
+  it('should return a <between> filter (with date)', () => {
+    const fieldFilter = new FieldFilter({
+      query: built,
+      prop: 'name',
+      lookup: LookupFilter.BETWEEN,
+      value: '2022-08-01,2022-11-22',
+    })
+    fieldFilter.buildQuery()
+    expect(built['where']['name']).toEqual(Between('2022-08-01', '2022-11-22'))
+  })
+
   it('should return a <in> filter', () => {
     const fieldFilter = new FieldFilter({
       query: built,


### PR DESCRIPTION
 ##### 📌 specs  
+ map rangeValues to not  convert everything to intergers parameters
+ add an unit test on 'date' `between` (particularly for DC needs)

#### Before changes : 

###### -- with date ❌
<img width="366" alt="image" src="https://user-images.githubusercontent.com/15196295/190143046-3b65d576-ae48-4589-9451-b2b00716a25f.png">

###### -- with number ✅
<img width="388" alt="image" src="https://user-images.githubusercontent.com/15196295/190142925-a9b8a90f-4697-4356-8b28-1afeb978a142.png">


#### After changes :
###### -- with number ✅
<img width="389" alt="image" src="https://user-images.githubusercontent.com/15196295/190141605-c94a5c63-0084-46a6-9994-ed68a519d1ef.png">

###### -- with date ✅
<img width="369" alt="image" src="https://user-images.githubusercontent.com/15196295/190141289-b0bbf281-d4b1-491a-84bf-3b63cced5026.png">
